### PR TITLE
chore: update azure deps to 0.35 and reqwest to 0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688882dc4a96b0ea158299d590fad91c471eced6403fd9a9ea1992c14397f25f"
+checksum = "9966f75417a6779ea221531960d9d46fe630879606501aa5277312ad4ae38587"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8392bbf0028c43df2f69422825721614f47e12fd601f9056df2c18d35c57e0"
+checksum = "385e4426c01965149a002a72c54c43d6f1b9d2244179e70647df48e3b28f8c32"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2091,9 +2091,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2908,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66166c78ee5b5a03b665a639899414a468f645f58dba3c8154b82d64847d227b"
+checksum = "4714a935f6aa74724775f07291390e8f07df0a1804544cd4106ac3b75c0478d2"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ license = "MIT"
 [dependencies]
 clap = { version = "4.6.1", features = ["derive", "cargo"] }
 tokio = { version = "^1.52.1", features = ["macros", "rt-multi-thread"] }
-azure_core = "^0.34"
-azure_identity = "^0.34"
+azure_core = "^0.35"
+azure_identity = "^0.35"
 url = "2.5.8"
-reqwest = { version = "0.13.2", features = ["json", "query"] }
+reqwest = { version = "0.13.3", features = ["json", "query"] }
 serde = "1.0.228"
 tabled = { version = "^0.20", features = ["ansi"] }
 chrono = { version = "0.4.44", features = ["serde"] }


### PR DESCRIPTION
## Summary
- Bump `azure_core` and `azure_identity` from 0.34 to 0.35
- Bump `reqwest` from 0.13.2 to 0.13.3

## Test plan
- [x] `cargo build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies for enhanced stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->